### PR TITLE
Fix duplicate account-detail cards on login

### DIFF
--- a/backend.php
+++ b/backend.php
@@ -119,7 +119,7 @@ session_start();
         }
         if(isset($_GET['account_details'])){
             echo'
-                <div id = "info" class="card border-dark" style="width: 15%;border-width:2px">
+                <div id="currentValue" class="card border-dark" style="width: 15%;border-width:2px">
                     <div class="card-body col-sm" style="background:#131722;">
                     <h5 class="card-title text-muted">Current Value:</h5>
                     <h6 class="card-subtitle mb-2 " style="color:';
@@ -134,7 +134,7 @@ session_start();
                 </div>
             
             
-                <div  id = "info" class="card border-dark" style="width: 15%;border-width:2px">
+                <div id="buyingPower" class="card border-dark" style="width: 15%;border-width:2px">
                     <div class="card-body col-sm" style="background:#131722;">
                     <h5 class="card-title text-muted">Buying Power:</h5>
                     <h6 class="card-subtitle mb-2" style="color:';
@@ -151,7 +151,7 @@ session_start();
             ';
             if($account->pattern_dat_trader){
             echo'
-                <div id = "info" class="card border-dark" style="width: 15%;border-width:2px">
+                <div id="dayTrader" class="card border-dark" style="width: 15%;border-width:2px">
                     <div class="card-body col-sm" style="background:#131722;">
                     <h5 class="card-title " style = "color:red;">Day Trader:</h5>
                     <h6 class="card-subtitle mb-2 " style="color:grey;">'.$account->pattern_day_trader.'</h6>
@@ -160,8 +160,7 @@ session_start();
             ';}
             if($account->trading_blocked){
             echo '
-            
-                <div id = "info" class="card border-dark" style="width: 15%;border-width:2px">
+                <div id="tradingBlocked" class="card border-dark" style="width: 15%;border-width:2px">
                     <div class="card-body col-sm" style="background:#131722;">
                     <h5 class="card-title " style = "color:red;">Trading Blocked:</h5>
                     <h6 class="card-subtitle mb-2 " style="color:grey;">'.$account->trading_blocked.'</h6>

--- a/index.php
+++ b/index.php
@@ -2,11 +2,16 @@
 <html>
 
 <head>
-      <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
- <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+    <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+    <style>
+        .card:last-child {
+            margin-right: 20px;
+        }
+    </style>
 </head>
 
 <body style="background:#212529">

--- a/script.js
+++ b/script.js
@@ -8,6 +8,8 @@ $("document").ready(function() {
    $("#submitButton").click(
        function(){
            console.log('submit');
+           // Remove existing account-detail cards
+           $('.card').remove();
             $.ajax({
                     type: "POST",
                     url: "backend.php",


### PR DESCRIPTION
### Issue: 
Everytime you press the **login** button, additional account-detail cards are being added.


<img width="1051" alt="Screen Shot 2019-03-21 at 10 23 18 PM" src="https://user-images.githubusercontent.com/16360374/54802853-52066900-4c2a-11e9-8a04-714b5be92856.png">

### Changes: 
  * Removed existing account-detail cards on login submission
  * Prevented duplicate IDs on account-detail cards
  * Align account-detail cards with tradingview chart

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cruddyshad0w/alpaca-wrangler/1)
<!-- Reviewable:end -->
